### PR TITLE
Fixed onStyleClick id reference

### DIFF
--- a/client/src/components/overview/Overview.jsx
+++ b/client/src/components/overview/Overview.jsx
@@ -67,9 +67,9 @@ const Overview = ({ productId }) => {
       });
   }, [productId])
 
-  const onStyleClick = (id) => {
+  const onStyleClick = (e, id) => {
     for (var i = 0; i < styleData.length; i++) {
-      if (styleData[i].style_id === ID) {
+      if (styleData[i].style_id === id) {
         setCurrentStyle(styleData[i]);
       }
     }


### PR DESCRIPTION
"id" got turned to "ID" during a merge conflict. Fixed, style selector should be working again. Please review and let me know when it's okay to merge. 